### PR TITLE
環境変数のセット&CIフロー追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          architecture: x64
+      - run: flutter pub get
+      - run: flutter test
+      - run: flutter build ios --release --no-codesign

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "todolist-flutter-app",
+            "request": "launch",
+            "type": "dart",
+            "toolArgs": [
+                "--dart-define", "API_URL=http://localhost:8080"
+            ]
+        }
+    ]
+}

--- a/lib/common/config.dart
+++ b/lib/common/config.dart
@@ -1,0 +1,3 @@
+class AppConfig {
+  static String apiURL = const String.fromEnvironment('API_URL');
+}

--- a/lib/services/api/task.dart
+++ b/lib/services/api/task.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:todolist_flutter_app/common/config.dart';
 import 'package:todolist_flutter_app/models/task.dart';
 import 'package:todolist_flutter_app/services/api/client.dart';
 import 'package:todolist_flutter_app/services/firebase/auth.dart';
@@ -38,6 +39,5 @@ class TaskRepository {
 final taskRepositoryProvider = Provider((ref) {
   final auth = ref.watch(firebaseAuthProvider);
   return TaskRepository(
-      client: CustomClient(firebaseAuth: auth),
-      baseURL: 'http://localhost:8080');
+      client: CustomClient(firebaseAuth: auth), baseURL: AppConfig.apiURL);
 });


### PR DESCRIPTION
# 概要
- 環境ごとに値をセットできるようにdart-defineの定義を追加
  - flavor分けるとかは今回はやめた
- テストおよびビルドを自動実行するCIフローを追加
  - App DistributionへのCDも検討したがアカウント設定などが手間だったのでこちらも省略